### PR TITLE
Update csharp-6

### DIFF
--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -508,12 +508,12 @@ if any, is lost.
 ## Index Initializers
 
 *Index Initializers* is one of two features that make collection
-initializers more consistent. In earlier releases of C#, you could use
-*collection initializers* only with sequence style collections:
+initializers more consistent with index usage. In earlier releases of C#, you could use
+*collection initializers* only with sequence style collections, including <xref:System.Collections.Generic.Dictionary%602> by adding braces around the Key-Value pairs:
 
 [!code-csharp[ListInitializer](../../../samples/snippets/csharp/new-in-6/initializers.cs#ListInitializer)]
 
-Now, you can also use them with <xref:System.Collections.Generic.Dictionary%602> collections and similar types:
+Now, you can use them with <xref:System.Collections.Generic.Dictionary%602> collections and similar types making index initialization more consistent with index usage:
 
 [!code-csharp[DictionaryInitializer](../../../samples/snippets/csharp/new-in-6/initializers.cs#DictionaryInitializer)]
 


### PR DESCRIPTION
## Summary

Minor updates to Index initializer verbiage adding that Dictionary is still able to be initialized using collection initializer and focusing change on the fact that we are now using indexer allowing users to be more consistent with its actual usage/assignment.

Fixes #Issue_Number 5169
